### PR TITLE
Pin click==8.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     python_requires=">=3.6",
     zip_safe=False,
     install_requires=[
-        "click>=7.1.2",
+        "click==8.0.4",
         "appdirs",
         "toml>=0.10.1",
         "typed-ast>=1.4.0",


### PR DESCRIPTION
See: https://github.com/psf/black/issues/2964#issuecomment-1080971383.

This is also the version we pin click to in applied2.

Seeing this error without `click` pinned
```
Traceback (most recent call last):
  File "/home/young/.local/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/young/.local/lib/python3.8/site-packages/black/__init__.py", line 6609, in patched_main
    patch_click()
  File "/home/young/.local/lib/python3.8/site-packages/black/__init__.py", line 6598, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/young/.local/lib/python3.8/site-packages/click/__init__.py)
```